### PR TITLE
Doesn't work with some requests (iPad)

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgress.m
+++ b/NJKWebViewProgress/NJKWebViewProgress.m
@@ -94,8 +94,11 @@ static const float afterInteractiveMaxProgressValue = 0.9;
         NSString *nonFragmentURL = [request.URL.absoluteString stringByReplacingOccurrencesOfString:[@"#" stringByAppendingString:request.URL.fragment] withString:@""];
         isFragmentJump = [nonFragmentURL isEqualToString:webView.request.URL.absoluteString];
     }
+
+    BOOL isTopLevelNavigation = [request.mainDocumentURL isEqual:request.URL];
+
     BOOL isHTTP = [request.URL.scheme isEqualToString:@"http"] || [request.URL.scheme isEqualToString:@"https"];
-    if (ret && !isFragmentJump && isHTTP && navigationType != UIWebViewNavigationTypeOther && navigationType != UIWebViewNavigationTypeBackForward) {
+    if (ret && !isFragmentJump && isHTTP && isTopLevelNavigation && navigationType != UIWebViewNavigationTypeBackForward) {
         [self reset];
     }
     return ret;


### PR DESCRIPTION
Hello,

I have tried you component on iPad but only the first request send the progress to the delegate.
After, values are only 0.9 and 1, but completeProgress is never called.

For example, search on google and clic on a link.
For the google search, it works, but not for the next link.

I think iPad can be different of iPhone for javascript events ?
