### PR TITLE
Not working with Back & Forward buttons

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgress.m
+++ b/NJKWebViewProgress/NJKWebViewProgress.m
@@ -99,7 +99,7 @@ static const float afterInteractiveMaxProgressValue = 0.9;
     BOOL isTopLevelNavigation = [request.mainDocumentURL isEqual:request.URL];
 
     BOOL isHTTP = [request.URL.scheme isEqualToString:@"http"] || [request.URL.scheme isEqualToString:@"https"];
-    if (ret && !isFragmentJump && isHTTP && isTopLevelNavigation && navigationType != UIWebViewNavigationTypeBackForward) {
+    if (ret && !isFragmentJump && isHTTP && isTopLevelNavigation) {
         _currentURL = request.URL;
         [self reset];
     }


### PR DESCRIPTION
I have a WebView with Back & Forward buttons on a toolbar hooked to goBack & goForward UIWebView actions. The progress bar doesn't show up. Please resolve.
