### PR TITLE
Publicize web view progress constants.

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgress.h
+++ b/NJKWebViewProgress/NJKWebViewProgress.h
@@ -14,6 +14,10 @@
 #define njk_weak unsafe_unretained
 #endif
 
+extern const float NJKInitialProgressValue;
+extern const float NJKInteractiveProgressValue;
+extern const float NJKFinalProgressValue;
+
 typedef void (^NJKWebViewProgressBlock)(float progress);
 @protocol NJKWebViewProgressDelegate;
 @interface NJKWebViewProgress : NSObject<UIWebViewDelegate>

--- a/NJKWebViewProgress/NJKWebViewProgress.m
+++ b/NJKWebViewProgress/NJKWebViewProgress.m
@@ -9,9 +9,9 @@
 
 NSString *completeRPCURL = @"webviewprogressproxy:///complete";
 
-static const float initialProgressValue = 0.1;
-static const float beforeInteractiveMaxProgressValue = 0.5;
-static const float afterInteractiveMaxProgressValue = 0.9;
+const float NJKInitialProgressValue = 0.1f;
+const float NJKInteractiveProgressValue = 0.5f;
+const float NJKFinalProgressValue = 0.9f;
 
 @implementation NJKWebViewProgress
 {
@@ -33,15 +33,15 @@ static const float afterInteractiveMaxProgressValue = 0.9;
 
 - (void)startProgress
 {
-    if (_progress < initialProgressValue) {
-        [self setProgress:initialProgressValue];
+    if (_progress < NJKInitialProgressValue) {
+        [self setProgress:NJKInitialProgressValue];
     }
 }
 
 - (void)incrementProgress
 {
     float progress = self.progress;
-    float maxProgress = _interactive ? afterInteractiveMaxProgressValue : beforeInteractiveMaxProgressValue;
+    float maxProgress = _interactive ? NJKFinalProgressValue : NJKInteractiveProgressValue;
     float remainPercent = (float)_loadingCount / (float)_maxLoadCount;
     float increment = (maxProgress - progress) * remainPercent;
     progress += increment;

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ progressProxy.progressBlock = ^(float progress) {
 };
 ```
 
+You can determine the current state of the document by comparing the `progress` value to one of the provided constants:
+
+```objc
+-(void)webViewProgress:(NJKWebViewProgress *)webViewProgress updateProgress:(float)progress
+{
+    if (progress == NJKInteractiveProgressValue) {
+        // The web view has finished parsing the document,
+        // but is still loading sub-resources
+    }
+}
+```
+
 This repository contains iOS 7 Safari style bar `NJKWebViewProgressView`. You can choose `NJKWebViewProgressView`, `UIProgressView` or your custom bar.
 
 # Install


### PR DESCRIPTION
Currently, a developer that wants to execute code when the DOM in a web
view has become interactive must write the following:

``` objc
-(void)webViewProgress:(NJKWebViewProgress *)webViewProgress
        updateProgress:(float)progress
{
    if (progress == 0.5) { /* ... */ }
}
```

In the above sample, `0.5` is a magic number.

Eliminate the need to use magic numbers by publicizing the constants
used internally: `0.1`, `0.5`, and `0.9`. This allows users to write the
following:

``` objc
if (progress == kNJKWebViewProgressBeforeInteractiveMaximum) { /* ... */ }
```
