### PR TITLE
Update NJKWebViewProgress.m

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgress.m
+++ b/NJKWebViewProgress/NJKWebViewProgress.m
@@ -163,7 +163,7 @@ const float NJKFinalProgressValue = 0.9f;
     
     BOOL isNotRedirect = _currentURL && [_currentURL isEqual:webView.request.mainDocumentURL];
     BOOL complete = [readyState isEqualToString:@"complete"];
-    if (complete && isNotRedirect) {
+    if ((complete && isNotRedirect) || error) {
         [self completeProgress];
     }
 }


### PR DESCRIPTION
Call `compleProgress` when encountering an error, e.g. trying to load a offline server url