### PR TITLE
update initial progress value to zero

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgressView.m
+++ b/NJKWebViewProgress/NJKWebViewProgressView.m
@@ -28,7 +28,7 @@
 {
     self.userInteractionEnabled = NO;
     self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    _progressBarView = [[UIView alloc] initWithFrame:self.bounds];
+    _progressBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, self.bounds.size.height)];
     _progressBarView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     UIColor *tintColor = [UIColor colorWithRed:22.f / 255.f green:126.f / 255.f blue:251.f / 255.f alpha:1.0]; // iOS7 Safari bar color
     if ([UIApplication.sharedApplication.delegate.window respondsToSelector:@selector(setTintColor:)] && UIApplication.sharedApplication.delegate.window.tintColor) {


### PR DESCRIPTION
The current initial progress progress bar is  100% , so the page first loads will lead to progress bar appears loaded twice. The progress bar is initialized to zero progress can be more friendly. If user want to set the progress can use `[_progressView setProgress:50 animated: NO]`;
