### PR TITLE
fix for  Invalid URL

### DIFF
--- a/NJKWebViewProgress/NJKWebViewProgress.m
+++ b/NJKWebViewProgress/NJKWebViewProgress.m
@@ -103,6 +103,12 @@ const float NJKFinalProgressValue = 0.9f;
         _currentURL = request.URL;
         [self reset];
     }
+    if (ret) {
+        _loadingCount++;
+        _maxLoadCount = fmax(_maxLoadCount, _loadingCount);
+        
+        [self startProgress];
+    }
     return ret;
 }
 
@@ -111,11 +117,6 @@ const float NJKFinalProgressValue = 0.9f;
     if ([_webViewProxyDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
         [_webViewProxyDelegate webViewDidStartLoad:webView];
     }
-
-    _loadingCount++;
-    _maxLoadCount = fmax(_maxLoadCount, _loadingCount);
-
-    [self startProgress];
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView


### PR DESCRIPTION
First of all ,Sorry , I'm a Chines , my English is not well 
The problem:
When I pass a Invalid URL just like htt22p://x.com,the webview delegate selector "shouldStartLoadWithRequest" return YES , but "webViewDidStartLoad" not be executed , as the same time, "didFailLoadWithError" is executed, so _loadingCount will Overflow, because it is NSUInteger and do this "loadingCount--". So I think take the start progress logic to shouldStartLoadWithRequest may be better.
